### PR TITLE
fix(i18n): use languages array (not its keys) for blog/404 static paths

### DIFF
--- a/.changeset/fix-i18n-numeric-locale-static-paths.md
+++ b/.changeset/fix-i18n-numeric-locale-static-paths.md
@@ -1,0 +1,5 @@
+---
+"fumapress": patch
+---
+
+Fix i18n: the blog index, blog tags-list, and localized 404 pages were registered under numeric locale paths (`/0`, `/1`, …) instead of locale codes, because their `staticPaths` used `Object.keys(i18nConfig.languages)` on the `languages` array (which yields its indices). Use the `languages` array directly.

--- a/packages/core/src/plugins/blog.tsx
+++ b/packages/core/src/plugins/blog.tsx
@@ -136,7 +136,7 @@ export function blogPlugin<C extends ConfigContext = ConfigContext>({
           path: this.i18nConfig
             ? (joinPathname("/[lang]/(blog)", blogCtx.indexPath) as "/[lang]")
             : (joinPathname("/(blog)", blogCtx.indexPath) as "/[lang]"),
-          staticPaths: this.i18nConfig ? Object.keys(this.i18nConfig.languages) : [],
+          staticPaths: this.i18nConfig ? this.i18nConfig.languages : [],
           component: IndexPage,
         });
       }
@@ -148,7 +148,7 @@ export function blogPlugin<C extends ConfigContext = ConfigContext>({
         createPage({
           path: joinPathname("/[lang]/(blog)", blogCtx.tagsPath) as "/[lang]",
           render: renderMode,
-          staticPaths: Object.keys(this.i18nConfig.languages),
+          staticPaths: this.i18nConfig.languages,
           component: TagsPage,
         });
 

--- a/packages/core/src/router/index.tsx
+++ b/packages/core/src/router/index.tsx
@@ -133,7 +133,7 @@ export async function createRouter<C extends ConfigContext>(
         fns.createPage({
           render: defaultRenderMode,
           path: "/[lang]/404",
-          staticPaths: Object.keys(context.i18nConfig.languages),
+          staticPaths: context.i18nConfig.languages,
           component: layouts.notFound,
         });
 


### PR DESCRIPTION
Fixes #41.

`defineI18n(...).languages` is a `string[]` of locale codes, but three `staticPaths` were built with `Object.keys(i18nConfig.languages)`, which returns the array **indices** (`['0','1',…]`). As a result the blog index, blog tags-list, and localized 404 pages register under `/0`, `/1`, … instead of `/en`, `/de`, … — so `/{locale}/blog` and `/{locale}/blog/tags` 404, and the numeric paths leak into `sitemap.xml`. Blog posts and tag pages are unaffected because they already use the locale value directly.

This swaps the three call sites to use `i18nConfig.languages` directly:

- `packages/core/src/plugins/blog.tsx` — blog index + tags-list
- `packages/core/src/router/index.tsx` — localized 404

Observed in a Waku + Fumapress 0.6.1 app with `defineI18n({ languages: ['en', 'hk', 'ja'] })`: `/en/blog` 307s and `sitemap.xml` contains `/0/blog`, `/1/blog`, `/2/blog`. The change is type-preserving (`string[]` → `string[]`). A `patch` changeset is included.
