### PR TITLE
fix(core): accept string dates in core:get-creation-date

### DIFF
--- a/.tegami/2026-08-27-mdx-creation-date.md
+++ b/.tegami/2026-08-27-mdx-creation-date.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:fumapress: patch
+---
+
+### Accept string dates in `core:get-creation-date`
+
+Fumadocs MDX serializes frontmatter as JSON, so a `date` field reaches the adapter as a string.
+The hook only accepted `Date` objects and returned `undefined` otherwise, which made blog posts fall
+back to the build time. It now parses strings, like `tegami:get-date` already did.

--- a/packages/core/src/adapters/mdx.ts
+++ b/packages/core/src/adapters/mdx.ts
@@ -53,11 +53,7 @@ export function fumadocsMdx<C extends AppShape = AppShape>(
       if (isSyncEntry(page.data)) return page.data.toc;
       if (isAsyncEntry(page.data)) return (await page.data.load()).toc;
     },
-    "core:get-creation-date"(page) {
-      if (isSyncEntry(page.data) || isAsyncEntry(page.data)) {
-        return "date" in page.data && page.data.date instanceof Date ? page.data.date : undefined;
-      }
-    },
+    "core:get-creation-date": getDate,
     async "core:get-modified-date"(page) {
       let data: object;
 
@@ -77,13 +73,15 @@ export function fumadocsMdx<C extends AppShape = AppShape>(
         return parsed.success ? parsed.data.tags : undefined;
       }
     },
-    "tegami:get-date"(page: C["page"]) {
-      if ((isSyncEntry(page.data) || isAsyncEntry(page.data)) && "date" in page.data) {
-        if (page.data.date instanceof Date) return page.data.date;
-        if (typeof page.data.date === "string") return new Date(page.data.date);
-      }
-    },
+    "tegami:get-date": getDate,
   } as Adapter<C>;
+}
+
+function getDate(page: AppShape["page"]) {
+  if ((isSyncEntry(page.data) || isAsyncEntry(page.data)) && "date" in page.data) {
+    if (page.data.date instanceof Date) return page.data.date;
+    if (typeof page.data.date === "string") return new Date(page.data.date);
+  }
 }
 
 const tagsSchema = z.looseObject({


### PR DESCRIPTION
Fumadocs MDX writes the validated frontmatter into the module with `JSON.stringify`, so a `date` field always reaches the adapter as a string:

https://github.com/fuma-nama/fumadocs/blob/a664496ca79c46ca478bb2700439252f5218f45d/packages/mdx/src/loaders/mdx/index.ts#L98-L103

The mdx adapter's `core:get-creation-date` only accepted a `Date` instance and returned `undefined` otherwise:

https://github.com/fuma-nama/fumapress/blob/d4a27e41b3785cdfa02f17291354754f789d423c/packages/core/src/adapters/mdx.ts#L56-L60

With the blog plugin, every post then fell back to the build time, so the index showed the wrong date and the order was lost:

https://github.com/fuma-nama/fumapress/blob/d4a27e41b3785cdfa02f17291354754f789d423c/packages/core/src/components/blog.tsx#L26-L31

`tegami:get-date` in the same file already handles the string case:

https://github.com/fuma-nama/fumapress/blob/d4a27e41b3785cdfa02f17291354754f789d423c/packages/core/src/adapters/mdx.ts#L80-L85

This change shares one `getDate` helper between both hooks.
