### PR TITLE
fix(core): treat data: images as unoptimized

### DIFF
--- a/.tegami/2026-08-29-image-data-src.md
+++ b/.tegami/2026-08-29-image-data-src.md
@@ -1,0 +1,10 @@
+---
+packages:
+  npm:fumapress: patch
+---
+
+### Treat `data:` images as unoptimized
+
+Vite inlines a small image as a `data:` URL at build time. `Image` sent this URL to the image
+optimizer. An optimizer cannot fetch a `data:` URL, so Vercel returned `400 INVALID_IMAGE_OPTIMIZE_REQUEST`
+and the image did not show. `Image` now treats a `data:` src as unoptimized and renders a plain `<img>`.

--- a/packages/core/src/components/image.tsx
+++ b/packages/core/src/components/image.tsx
@@ -221,7 +221,7 @@ export function Image({
     };
   }, [_src, _width, _height, pathname]);
 
-  if (src && ctx?.provider.canOptimize && !ctx.provider.canOptimize(src)) {
+  if (src && (src.startsWith("data:") || ctx?.provider.canOptimize?.(src) === false)) {
     unoptimized = true;
   }
 


### PR DESCRIPTION
Vite inlines an image below `build.assetsInlineLimit` (4 KB) as a `data:` URL. `normalizeSrc` returns a `data:` src unchanged:

https://github.com/fuma-nama/fumapress/blob/1ce17b83b89e494dd3cb09632642a940c40a4b9b/packages/core/src/components/image.tsx#L91

`Image` then asks only the provider's `canOptimize`. It rejects SVG, not `data:`:

https://github.com/fuma-nama/fumapress/blob/1ce17b83b89e494dd3cb09632642a940c40a4b9b/packages/core/src/components/image.tsx#L224-L226

https://github.com/fuma-nama/fumapress/blob/1ce17b83b89e494dd3cb09632642a940c40a4b9b/packages/core/src/plugins/image/vercel.client.tsx#L21-L25

The `srcSet` becomes `/_vercel/image?url=data%3Aimage%2Fwebp%3Bbase64%2C...`. Vercel returns `400 INVALID_IMAGE_OPTIMIZE_REQUEST`. The Cloudflare and self-hosted providers cannot fetch a `data:` source either.

An optimizer needs an origin to fetch from, and a `data:` src has none. This PR makes `Image` treat a `data:` src as unoptimized, next to the `canOptimize` check, so each provider does not repeat the rule.

To reproduce: add an MDX image smaller than 4 KB. Run `VERCEL=1 fumapress build` and deploy. The image is missing on the page. The bug does not show in development, because `canOptimize` returns `false` when `import.meta.env.DEV` is set.
